### PR TITLE
Expose PropertyDescriptor label methods

### DIFF
--- a/Bindings/Bindings.idl
+++ b/Bindings/Bindings.idl
@@ -570,6 +570,8 @@ interface PropertyDescriptor {
     [Const, Ref] DOMString GetType();
     [Ref] PropertyDescriptor AddExtraInfo([Const] DOMString type);
     [Value] VectorString GetExtraInfo();
+    [Ref] PropertyDescriptor SetLabel([Const] DOMString label);
+    [Const, Ref] DOMString GetLabel();
 };
 
 interface MapStringPropertyDescriptor {


### PR DESCRIPTION
Sorry, forget to push this one, I think the extension is broken without it, as it calls the "setLabel" method.