### PR TITLE
Fix array parsing on fromJSObject

### DIFF
--- a/Bindings/Bindings.idl
+++ b/Bindings/Bindings.idl
@@ -802,6 +802,8 @@ interface SerializerElement {
     [Ref] SerializerElement GetChild([Const] DOMString str);
     void WRAPPED_SetChild([Const] DOMString str, [Const, Ref] SerializerElement element);
     boolean HasChild([Const] DOMString str);
+
+    void ConsiderAsArray();
 };
 
 interface Serializer {

--- a/Bindings/postjs.js
+++ b/Bindings/postjs.js
@@ -130,6 +130,7 @@
             } else if (typeof object === 'boolean') {
                 element.setBool(object);
             } else if (Array.isArray(object)) {
+                element.considerAsArray();
                 for(var i = 0;i<object.length;++i) {
                     var item = element.addChild("");
                     gd.Serializer._fromJSObject(object[i], item);


### PR DESCRIPTION
I think I've caught this elusive boy :D
The bug affected the vertices only because GD used a different parser (JSON,parse) in the game file and this one was not flagging the arrays.

We have very different versions of GD right now, I was able to test my version of libGD.js with this modification and now the vertices load correctly. But I'm unable to test it with the master, can you give it a try, please?

EDIT: Seems to work fine in the master branch.